### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/vberlier/rukt/compare/v0.1.0...v0.2.0) - 2024-11-13
+
+### Added
+
+- Add `rukt` macro
+
 ## [0.1.0](https://github.com/vberlier/rukt/releases/tag/v0.1.0) - 2024-11-13
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "rukt"
-version = "0.1.0"
+version = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rukt"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Simple Rust dialect for token-based compile-time scripting"


### PR DESCRIPTION
## 🤖 New release
* `rukt`: 0.1.0 -> 0.2.0 (⚠️ API breaking changes)

### ⚠️ `rukt` breaking changes

```
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/function_missing.ron

Failed in:
  function rukt::add, previously in file /tmp/.tmpt2jKbt/rukt/src/lib.rs:1
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/vberlier/rukt/compare/v0.1.0...v0.2.0) - 2024-11-13

### Added

- Add `rukt` macro
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).