### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/vberlier/rukt/compare/v0.2.0...v0.2.1) - 2024-11-15
+
+### Added
+
+- add basic initial syntax
+
 ## [0.2.0](https://github.com/vberlier/rukt/compare/v0.1.0...v0.2.0) - 2024-11-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "rukt"
-version = "0.2.0"
+version = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rukt"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Simple Rust dialect for token-based compile-time scripting"


### PR DESCRIPTION
## 🤖 New release
* `rukt`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/vberlier/rukt/compare/v0.2.0...v0.2.1) - 2024-11-15

### Added

- add basic initial syntax
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).