### PR TITLE
chore: release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/vberlier/rukt/compare/v0.2.2...v0.2.3) - 2024-11-18
+
+### Added
+
+- Add functions
+- Add starts_with
+- Add operators
+
+### Other
+
+- Add link to https://github.com/rust-lang/rust/issues/35853
+
 ## [0.2.2](https://github.com/vberlier/rukt/compare/v0.2.1...v0.2.2) - 2024-11-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "rukt"
-version = "0.2.2"
+version = "0.2.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rukt"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Simple Rust dialect for token-based compile-time scripting"


### PR DESCRIPTION
## 🤖 New release
* `rukt`: 0.2.2 -> 0.2.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.3](https://github.com/vberlier/rukt/compare/v0.2.2...v0.2.3) - 2024-11-18

### Added

- Add functions
- Add starts_with
- Add operators

### Other

- Add link to https://github.com/rust-lang/rust/issues/35853
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).